### PR TITLE
chore: bump raydium-amm-v3 to slim quoting SDK rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4573,14 +4573,13 @@ dependencies = [
 [[package]]
 name = "raydium-amm-v3"
 version = "0.1.0"
-source = "git+ssh://git@github.com/jup-ag/raydium-clmm.git?rev=447050692d0454fef80663830df65d4e546a8bc2#447050692d0454fef80663830df65d4e546a8bc2"
+source = "git+ssh://git@github.com/jup-ag/raydium-clmm.git?rev=be81db90af7ad9c1f6c11a6a23c41fb307bd3330#be81db90af7ad9c1f6c11a6a23c41fb307bd3330"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
  "arrayref",
  "bytemuck",
  "solana-program 4.0.0",
- "solana-security-txt",
  "spl-memo-interface",
  "uint",
 ]

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -27,7 +27,7 @@ enable-gpl = []
 anchor-lang = { workspace = true, features = ["event-cpi"] }
 anchor-spl = { workspace = true }
 arbitrary = { version = "~1.0", features = ["derive"], optional = true }
-raydium-amm-v3 = { git = "ssh://git@github.com/jup-ag/raydium-clmm.git", rev = "447050692d0454fef80663830df65d4e546a8bc2", features = [
+raydium-amm-v3 = { git = "ssh://git@github.com/jup-ag/raydium-clmm.git", rev = "be81db90af7ad9c1f6c11a6a23c41fb307bd3330", features = [
     "no-entrypoint",
 ] }
 arrayref = "0.3.6"


### PR DESCRIPTION
Bump to jup-ag/raydium-clmm@319dedc which removed the on-chain instruction handlers and supporting state types. openbook-v2 only reads PoolState's sqrt_price_x64 and mint_decimals_{0,1} (state/oracle.rs) and raydium_amm_v3::ID — all unchanged across the slimming.