### PR TITLE
chore: bump raydium-clmm to dust-stall fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3823,7 +3823,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -4313,7 +4313,7 @@ dependencies = [
  "num-traits",
  "pyth-sdk",
  "serde",
- "solana-program 3.0.0",
+ "solana-program 4.0.0",
  "thiserror 1.0.69",
 ]
 
@@ -4573,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "raydium-amm-v3"
 version = "0.1.0"
-source = "git+ssh://git@github.com/jup-ag/raydium-clmm.git?rev=be81db90af7ad9c1f6c11a6a23c41fb307bd3330#be81db90af7ad9c1f6c11a6a23c41fb307bd3330"
+source = "git+ssh://git@github.com/jup-ag/raydium-clmm.git?rev=225535ea74bb7aa3dd2c9fc99232f7a73af50e2c#225535ea74bb7aa3dd2c9fc99232f7a73af50e2c"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/openbook-v2/Cargo.toml
+++ b/programs/openbook-v2/Cargo.toml
@@ -27,7 +27,7 @@ enable-gpl = []
 anchor-lang = { workspace = true, features = ["event-cpi"] }
 anchor-spl = { workspace = true }
 arbitrary = { version = "~1.0", features = ["derive"], optional = true }
-raydium-amm-v3 = { git = "ssh://git@github.com/jup-ag/raydium-clmm.git", rev = "be81db90af7ad9c1f6c11a6a23c41fb307bd3330", features = [
+raydium-amm-v3 = { git = "ssh://git@github.com/jup-ag/raydium-clmm.git", rev = "225535ea74bb7aa3dd2c9fc99232f7a73af50e2c", features = [
     "no-entrypoint",
 ] }
 arrayref = "0.3.6"


### PR DESCRIPTION
## Summary

Bumps `raydium-amm-v3` from `be81db9` → `225535e` to pick up [jup-ag/raydium-clmm#14](https://github.com/jup-ag/raydium-clmm/pull/14), which adds a guard in `compute_swap` to surface the dust-stall condition as `LiquidityInsufficient` instead of CU-exhausting the on-chain swap loop.

Keeps this repo's rev pin aligned with `jupiter-core-rs`'s upcoming bump so we don't fork the SDK rev across the two consumers.

## Test plan

- [x] `cargo check -p openbook-v2` green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)